### PR TITLE
docs: move to conventional commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,9 +226,9 @@ When the body is present it must be at least 20 characters long and must conform
   │       │             │
   │       │             └─⫸ Summary in present tense. Not capitalized. No period at the end.
   │       │
-  │       └─⫸ Commit Scope: map|stations|auth|api|import
+  │       └─⫸ Commit Scope: map|stations|vehicles|auth|api|import
   │
-  └─⫸ Commit Type: ✨|♻️|🐛|🚑|📝
+  └─⫸ Commit Type: build|ci|docs|feat|fix|perf|refactor|test
 ```
 
 The `<type>` and `<summary>` fields are mandatory, the `(<scope>)` field is optional.
@@ -238,14 +238,15 @@ The `<type>` and `<summary>` fields are mandatory, the `(<scope>)` field is opti
 
 Must be one of the following:
 
-* **💚**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-* **👷**: Changes to our CI configuration files and scripts (examples: CircleCi, SauceLabs)
-* **📝**: Documentation only changes
-* **✨**: A new feature
-* **🐛**: A bug fix
-* **⚡️**: A code change that improves performance
-* **♻️**: A code change that neither fixes a bug nor adds a feature
-* **✅**: Adding missing tests or correcting existing tests
+* **build**: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
+* **ci**: Changes to our CI configuration files and scripts (examples: CircleCi, SauceLabs)
+* **docs**: Documentation only changes
+* **feat**: A new feature
+* **fix**: A bug fix
+* **perf**: A code change that improves performance
+* **refactor**: A code change that neither fixes a bug nor adds a feature
+* **test**: Adding missing tests or correcting existing tests
+
 
 
 ##### Scope
@@ -255,6 +256,7 @@ The following is the list of supported scopes:
 
 * `map`
 * `stations`
+* `vehicles`
 * `auth`
 * `api`
 * `import`
@@ -266,10 +268,6 @@ Use the summary field to provide a succinct description of the change:
 * use the imperative, present tense: "change" not "changed" nor "changes"
 * don't capitalize the first letter
 * no dot (.) at the end
-
-##### Example
-with scope `🐛(map): fix scrolling behaviour`
-without scope `✨ add download button`
 
 
 #### <a name="commit-body"></a>Commit Message Body


### PR DESCRIPTION
Updated the contributing guide to reflect our git commit convention.